### PR TITLE
Remove duplicate neighbors per query item.

### DIFF
--- a/sparselsh/lsh.py
+++ b/sparselsh/lsh.py
@@ -60,6 +60,7 @@ class LSH(object):
         self.hash_size = hash_size
         self.input_dim = input_dim
         self.num_hashtables = num_hashtables
+        self.indexed_counter = 0
 
         if storage_config is None:
             storage_config = {'dict': None}
@@ -222,7 +223,7 @@ class LSH(object):
 
                 # NOTE: needs to be tuple so it's set-hashable
                 for j in range(keys.shape[0]):
-                    value = tuple((input_points[j], j, extra_data[j]))
+                    value = tuple((input_points[j], self.indexed_counter + j, extra_data[j]))
                     table.append_val(keys[j].tobytes(), value)
         else:
             for i, table in enumerate(self.hash_tables):
@@ -232,8 +233,10 @@ class LSH(object):
 
                 # NOTE: needs to be tuple so it's set-hashable
                 for j in range(keys.shape[0]):
-                    value = tuple((input_points[j], j, None))
+                    value = tuple((input_points[j], self.indexed_counter + j, None))
                     table.append_val(keys[j].tobytes(), value)
+        
+        self.indexed_counter += input_points.shape[0]
 
     def _bytes_string_to_array(self, hash_key):
         """ Takes a hash key (bytes string) and turn it


### PR DESCRIPTION
Duplicates are removed from each query item's neighbor list by introducing unique IDs during indexing. This ID-based system only works if any points are indexed only once, because the second time any point is indexed it gets a different ID. Using some hash function like SHA may resolve this issue but not sure yet.

Also, small bug fixes and performance improvements all around.

However, these changes break backwards compatibility since when no extra_data is provided during indexing, None is passed as the value of the extra_data parameter for every indexed item and an indexed items counter is introduced in the index class.